### PR TITLE
Conditionally load the JS file and fix fatal on front end

### DIFF
--- a/bbpress-keyboard-shortcuts.php
+++ b/bbpress-keyboard-shortcuts.php
@@ -34,7 +34,7 @@ function bbpress_keyboard_shortcuts_check_bbpress() {
 		add_action( 'admin_notices', 'bbpress_keyboard_shortcuts_notice' );
 	}
 }
-add_action('init', 'bbpress_keyboard_shortcuts_check_bbpress');
+add_action('admin_init', 'bbpress_keyboard_shortcuts_check_bbpress');
 
 /**
  * Enqueue ALL the JS
@@ -43,8 +43,10 @@ add_action('init', 'bbpress_keyboard_shortcuts_check_bbpress');
  */
 function bbpress_keyboard_shortcuts_enqueue() {
 
-	//Enqueue the bbPress reply shortcut script (Only in the topic post type)
-	wp_enqueue_script( 'bbpress_reply_keyboard_shortcut', plugin_dir_url( __FILE__ ) . 'bbpress-keyboard-shortcut-reply.js' );
+	//Enqueue the bbPress reply shortcut script only in the bbPress area
+	if ( function_exists( 'is_bbpress' ) && is_bbpress() ) {
+		wp_enqueue_script( 'bbpress_reply_keyboard_shortcut', plugin_dir_url( __FILE__ ) . 'bbpress-keyboard-shortcut-reply.js' );
+	}
 
 }
 add_action('wp_enqueue_scripts','bbpress_keyboard_shortcuts_enqueue');


### PR DESCRIPTION
This addresses issue #8, by only enqueuing the `js` when we're on a `bbPress` page. Additionally it avoids a possible Fatal Error on the `is_plugin_active` call since this function is only part of the admin load, we should hook into `admin_init`, not `init`.
